### PR TITLE
Fix dev server reachability

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add `vite.config.js` so the Vite dev server binds to all interfaces

## Testing
- `python3 run_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6842de685f3083328396efaeae443c57