### PR TITLE
Allow CodeSandbox host

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173,
-    // Allow any host to connect, which is required for CodeSandbox
-    allowedHosts: 'all',
+    // Explicitly allow the CodeSandbox host
+    allowedHosts: ['cf9tvz-5173.csb.app'],
   },
 });


### PR DESCRIPTION
## Summary
- permit cf9tvz-5173.csb.app in `server.allowedHosts`

## Testing
- `python3 run_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6842e31603e88332901fea8c6e35a3b1